### PR TITLE
Update Expo router entry point configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fitdj",
   "version": "0.1.0",
   "private": true,
-  "main": "expo-main",
+  "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
     "android": "expo run:android",


### PR DESCRIPTION
## Summary
- point the Expo app's main entry to `expo-router/entry` so Metro loads the router entry point

## Testing
- npm install
- npm run start *(fails: Expo CLI cannot fetch native module versions due to `Forbidden` response in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b89e8218832ead35883025a23cb6